### PR TITLE
Add ARM/ARM64 to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
     - linux
   goarch:
     - amd64
+    - arm
+    - arm64
 archives:
 - replacements:
     darwin: Darwin

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This is a client for [vpngate.net](https://www.vpngate.net/).
 
 ![vpngate](https://user-images.githubusercontent.com/4519234/104145615-b6f9f880-5395-11eb-812c-c6597a7aed0f.gif)
 
-This client fetches the list of available relay servers provided by vpngate.net.
+This client fetches the list of available relay servers provided by vpngate.net, and allows you to filter and connect to a server of your liking.
 
 You can check out your current IP address and region at https://nordvpn.com/what-is-my-ip/, or simply run the following command in a terminal:
 
-```console
-$ curl ipinfo.io
+```shell
+curl ipinfo.io
 ```
 
 ## Requirements
@@ -19,69 +19,75 @@ $ curl ipinfo.io
 
 ## Install
 
+The simplest method of installation is using homebrew. You can also build from source.
 
-### homebrew
+### from homebrew
 
 vpngate can be installed with [homebrew](https://brew.sh/):
 
-```sh
+```shell
+# Ensure that Xcode is installed
+sudo xcode-select --install
+
+# OpenVPN is required
 brew install openvpn
+
 brew install davegallant/public/vpngate
 ```
 
-### source
+### from source
 
 Ensure that [go](https://golang.org/doc/install) is installed.
 
-```console
-$ CGO_ENABLED=0 go get github.com/davegallant/vpngate
+```shell
+CGO_ENABLED=0 go get github.com/davegallant/vpngate
 ```
 
 Ensure that the go bin path is discoverable:
 
-```console
-$ echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.profile
-$ source ~/.profile
+```shell
+echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.profile
+source ~/.profile
 ```
 
 ## Usage
 
 ### List available servers
 
-```console
-$ vpngate list
+```shell
+vpngate list
 ```
 
 ### Connect to a server
 
 On macOS, `openvpn` may not be within your PATH. To fix this, run:
 
-```console
-$ export PATH=$(brew --prefix openvpn)/sbin:$PATH
+```shell
+export PATH=$(brew --prefix openvpn)/sbin:$PATH
 ```
 
 The above command can also be added to a bash/zsh profile for future use.
 
 Because openvpn creates a network interface, run the connect command with `sudo` or a user with escalated privileges.
 
-```console
-$ sudo vpngate connect
+```shell
+sudo vpngate connect
 ```
 
 #### Random
 
 If the country doesn't matter, a random server can be selected:
 
-```console
-$ sudo vpngate connect --random
+```shell
+sudo vpngate connect --random
 ```
 
 #### Reconnect
 
 To continually attempt to reconnect (this can be combined with `--random`):
 
-```console
-$ sudo vpngate connect --reconnect
+```shell
+sudo vpngate connect --reconnect
 ```
 
 ## Notes


### PR DESCRIPTION
Cryptic error (https://github.com/goreleaser/goreleaser/issues/2389) was caused by not publishing arm64 architecture.